### PR TITLE
Freeze oorandom because it's behavior is in API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libc = "0.2"
-oorandom = "11.1.0"
+oorandom = "=11.1.0"
 bzip2 = "0.3"
 flate2 = "1.0"
 zstd = "0.4"


### PR DESCRIPTION
This should fix the CI-failure.