### PR TITLE
Mark free_str function as unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,29 +74,29 @@ impl Default for CResult {
 }
 
 #[no_mangle]
-pub extern "C" fn free_str(originally_from_rust: *mut c_void) {
-    let _will_drop: CString = unsafe { CString::from_raw(originally_from_rust as *mut c_char) };
+pub unsafe extern "C" fn free_str(originally_from_rust: *mut c_void) {
+    let _will_drop: CString =  CString::from_raw(originally_from_rust as *mut c_char);
 }
 
 /// Note: not-recursive. Free Error Message Manually!
 #[no_mangle]
-pub extern "C" fn free_c_result(originally_from_rust: *mut CResult) {
-    let _will_drop: Box<CResult> = unsafe { Box::from_raw(originally_from_rust) };
+pub unsafe extern "C" fn free_c_result(originally_from_rust: *mut CResult) {
+    let _will_drop: Box<CResult> = Box::from_raw(originally_from_rust);
 }
 
 #[no_mangle]
-pub extern "C" fn free_dataset(originally_from_rust: *mut CDataset) {
-    let _will_drop: Box<CDataset> = unsafe { Box::from_raw(originally_from_rust) };
+pub unsafe extern "C" fn free_dataset(originally_from_rust: *mut CDataset) {
+    let _will_drop: Box<CDataset> = Box::from_raw(originally_from_rust);
 }
 
 #[no_mangle]
-pub extern "C" fn free_model(originally_from_rust: *mut CModel) {
-    let _will_drop: Box<CModel> = unsafe { Box::from_raw(originally_from_rust) };
+pub unsafe extern "C" fn free_model(originally_from_rust: *mut CModel) {
+    let _will_drop: Box<CModel> = Box::from_raw(originally_from_rust);
 }
 
 #[no_mangle]
-pub extern "C" fn free_cqrel(originally_from_rust: *mut CQRel) {
-    let _will_drop: Box<CQRel> = unsafe { Box::from_raw(originally_from_rust) };
+pub unsafe extern "C" fn free_cqrel(originally_from_rust: *mut CQRel) {
+    let _will_drop: Box<CQRel> = Box::from_raw(originally_from_rust);
 }
 
 #[no_mangle]
@@ -115,8 +115,8 @@ pub extern "C" fn cqrel_from_json(json_str: *const c_void) -> *const CResult {
 }
 
 #[no_mangle]
-pub extern "C" fn cqrel_query_json(cqrel: *const CQRel, query_str: *const c_void) -> *const c_void {
-    let cqrel: Option<&CQRel> = unsafe { (cqrel as *mut CQRel).as_ref() };
+pub unsafe extern "C" fn cqrel_query_json(cqrel: *const CQRel, query_str: *const c_void) -> *const c_void {
+    let cqrel: Option<&CQRel> = (cqrel as *mut CQRel).as_ref();
     result_to_json(result_cqrel_query_json(
         cqrel,
         accept_str("query_str", query_str),
@@ -142,11 +142,11 @@ pub extern "C" fn load_ranksvm_format(
 }
 
 #[no_mangle]
-pub extern "C" fn dataset_query_sampling(
+pub unsafe extern "C" fn dataset_query_sampling(
     dataset: *mut CDataset,
     queries_json_list: *const c_void,
 ) -> *const CResult {
-    let dataset: Option<&CDataset> = unsafe { (dataset as *mut CDataset).as_ref() };
+    let dataset: Option<&CDataset> = (dataset as *mut CDataset).as_ref();
     result_to_c(
         result_dataset_query_sampling(dataset, accept_str("queries_json_list", queries_json_list))
             .map(|response| CDataset {
@@ -156,11 +156,11 @@ pub extern "C" fn dataset_query_sampling(
 }
 
 #[no_mangle]
-pub extern "C" fn dataset_feature_sampling(
+pub unsafe extern "C" fn dataset_feature_sampling(
     dataset: *mut CDataset,
     feature_json_list: *const c_void,
 ) -> *const CResult {
-    let dataset: Option<&CDataset> = unsafe { (dataset as *mut CDataset).as_ref() };
+    let dataset: Option<&CDataset> = (dataset as *mut CDataset).as_ref();
     result_to_c(
         result_dataset_feature_sampling(
             dataset,
@@ -173,11 +173,11 @@ pub extern "C" fn dataset_feature_sampling(
 }
 
 #[no_mangle]
-pub extern "C" fn dataset_query_json(
+pub unsafe extern "C" fn dataset_query_json(
     dataset: *mut c_void,
     json_cmd_str: *mut c_void,
 ) -> *const c_void {
-    let dataset: Option<&CDataset> = unsafe { (dataset as *mut CDataset).as_ref() };
+    let dataset: Option<&CDataset> = (dataset as *mut CDataset).as_ref();
     result_to_json(result_dataset_query_json(
         dataset,
         accept_str("dataset_query_json", json_cmd_str),
@@ -190,7 +190,7 @@ pub extern "C" fn query_json(json_cmd_str: *const c_void) -> *const c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn make_dense_dataset_f32_f64_i64(
+pub unsafe extern "C" fn make_dense_dataset_f32_f64_i64(
     n: usize,
     d: usize,
     x: *const f32,
@@ -198,9 +198,9 @@ pub extern "C" fn make_dense_dataset_f32_f64_i64(
     qids: *const i64,
 ) -> *const CResult {
     let x_len = n * d;
-    let x_slice: &'static [f32] = unsafe { slice::from_raw_parts(x, x_len) };
-    let y_slice: &'static [f64] = unsafe { slice::from_raw_parts(y, n) };
-    let qid_slice: &'static [i64] = unsafe { slice::from_raw_parts(qids, n) };
+    let x_slice: &'static [f32] = slice::from_raw_parts(x, x_len);
+    let y_slice: &'static [f64] = slice::from_raw_parts(y, n);
+    let qid_slice: &'static [i64] = slice::from_raw_parts(qids, n);
     result_to_c(
         DenseDataset::try_new(n, d, x_slice, y_slice, qid_slice).map(|dd| CDataset {
             reference: dd.into_ref(),
@@ -209,11 +209,11 @@ pub extern "C" fn make_dense_dataset_f32_f64_i64(
 }
 
 #[no_mangle]
-pub extern "C" fn train_model(
+pub unsafe extern "C" fn train_model(
     train_request_json: *mut c_void,
     dataset: *mut c_void,
 ) -> *const CResult {
-    let dataset: Option<&CDataset> = unsafe { (dataset as *mut CDataset).as_ref() };
+    let dataset: Option<&CDataset> = (dataset as *mut CDataset).as_ref();
     let request: Result<TrainRequest, _> =
         deserialize_from_cstr_json(accept_str("train_request_json", train_request_json));
     result_to_c(result_train_model(request, dataset).map(|actual| CModel { actual }))
@@ -228,11 +228,11 @@ pub extern "C" fn model_from_json(json_str: *const c_void) -> *const CResult {
 }
 
 #[no_mangle]
-pub extern "C" fn model_query_json(
+pub unsafe extern "C" fn model_query_json(
     model: *const c_void,
     json_cmd_str: *const c_void,
 ) -> *const c_void {
-    let model: Option<&CModel> = unsafe { (model as *const CModel).as_ref() };
+    let model: Option<&CModel> = (model as *const CModel).as_ref();
     result_to_json(result_model_query_json(
         model,
         accept_str("query_json", json_cmd_str),
@@ -241,36 +241,36 @@ pub extern "C" fn model_query_json(
 
 /// returns json of qid->score for evaluator; or error-json.
 #[no_mangle]
-pub extern "C" fn evaluate_by_query(
+pub unsafe extern "C" fn evaluate_by_query(
     model: *const CModel,
     dataset: *const CDataset,
     qrel: *const CQRel,
     evaluator: *const c_void,
 ) -> *const c_void {
-    let model: Option<&CModel> = unsafe { (model as *const CModel).as_ref() };
-    let dataset: Option<&CDataset> = unsafe { (dataset as *const CDataset).as_ref() };
-    let qrel: Option<&CQRel> = unsafe { (qrel as *const CQRel).as_ref() };
+    let model: Option<&CModel> = (model as *const CModel).as_ref();
+    let dataset: Option<&CDataset> = (dataset as *const CDataset).as_ref();
+    let qrel: Option<&CQRel> = (qrel as *const CQRel).as_ref();
     let evaluator: Result<&str, Box<dyn Error>> = accept_str("evaluator_name", evaluator);
     result_to_json(result_evaluate_by_query(model, dataset, qrel, evaluator))
 }
 
 #[no_mangle]
-pub extern "C" fn predict_scores(model: *const CModel, dataset: *const CDataset) -> *const c_void {
-    let model: Option<&CModel> = unsafe { (model as *const CModel).as_ref() };
-    let dataset: Option<&CDataset> = unsafe { (dataset as *const CDataset).as_ref() };
+pub unsafe extern "C" fn predict_scores(model: *const CModel, dataset: *const CDataset) -> *const c_void {
+    let model: Option<&CModel> = (model as *const CModel).as_ref();
+    let dataset: Option<&CDataset> = (dataset as *const CDataset).as_ref();
     result_to_json(result_predict_scores(model, dataset))
 }
 
 #[no_mangle]
-pub extern "C" fn predict_to_trecrun(
+pub unsafe extern "C" fn predict_to_trecrun(
     model: *const CModel,
     dataset: *const CDataset,
     output_path: *const c_void,
     system_name: *const c_void,
     depth: usize,
 ) -> *const c_void {
-    let model: Option<&CModel> = unsafe { (model as *const CModel).as_ref() };
-    let dataset: Option<&CDataset> = unsafe { (dataset as *const CDataset).as_ref() };
+    let model: Option<&CModel> = (model as *const CModel).as_ref();
+    let dataset: Option<&CDataset> = (dataset as *const CDataset).as_ref();
     let output_path: Result<&str, Box<dyn Error>> = accept_str("output_path", output_path);
     let system_name: Result<&str, Box<dyn Error>> = accept_str("system_name", system_name);
     result_to_json(result_predict_to_trecrun(


### PR DESCRIPTION
https://github.com/jjfiv/fastrank/blob/4d3b57f96463db08ee35e8ed4c2de27ad19932de/src/lib.rs#L77-L79
Hello, this function needs the unsafe keyword, because when we use the from_raw method, we are converting a raw pointer into a CString object, which is an unsafe operation. It requires us to guarantee that the passed pointer is valid, the pointed-to memory is not freed, and it meets the constraints of the CString type (i.e., null-terminated). Therefore, to avoid potential memory safety issues, we must use the unsafe keyword to mark this operation and explicitly indicate that it is an unsafe operation.
[https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw](url)
it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the free_str function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.
