### PR TITLE
attrs -> dataclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ Cargo.lock
 *.dylib
 .mypy_cache
 *.tar.gz
-examples/msn30k*.gz
+examples/msn30k*
 fastrank/fastrank
+/dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastrank"
-version = "0.7.0"
+version = "0.8.0-dev"
 authors = ["John Foley <johnf@middlebury.edu>"]
 edition = "2018"
 readme = "README.md"
@@ -25,4 +25,3 @@ serde_json = "1"
 serde_derive = "1"
 ordered-float = { version = "3.0", features = ["serde"] }
 fast-float = "0.2"
-

--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ My most frequently used learning-to-rank algorithms ported to rust for efficienc
 
 Read my [blog-post](https://jjfoley.me/2019/10/11/fastrank-alpha.html) announcing the first public version: 0.4. It's alpha because I think the API needs work, not because there's any sort of known correctness or compatiblity issues.
 
-## Python Requirement
+## Python Requirements / Release History
 
- - 0.5 and earlier require only Python 3.5, but no windows builds were pushed.
- - 0.6 requires Python 3.6 due to EOL for Python 3.5 becoming prevalent in the latest pip.
- - 0.6.1 switched to manylinux2010 building; you might get better vectorization from a local copy.
- - 0.7 maintains the requirement of Python 3.6
- - 0.8 and forward will require Python 3.7 so we can use the standard @dataclass annotation and drop the attrs dependency.
+- 0.5 and earlier require only Python 3.5, but no windows builds were pushed.
+- 0.6 requires Python 3.6 due to EOL for Python 3.5 becoming prevalent in the latest pip.
+- 0.6.1 switched to manylinux2010 building; you might get better vectorization from a local copy.
+- 0.7 maintains the requirement of Python 3.6
+- 0.8 and forward will require Python 3.7 so we can use the standard @dataclass annotation and drop the attrs dependency.
 
-## Python Usage 
+## Python Usage
 
 ```shell
 pip install fastrank
 ```
 
 See this [Colab notebook](https://colab.research.google.com/drive/1IjF7yTin1XaNO_6mBNxAoQYTmF0nckk1) for more, or see a static version [here on Github](https://github.com/jjfiv/fastrank/blob/master/examples/FastRankDemo.ipynb).
-

--- a/fastrank/training.py
+++ b/fastrank/training.py
@@ -1,66 +1,66 @@
-import attr
-from typing import Union, Any, Dict
+from typing import Union, Any, Dict, Optional
 import random
 from .clib import CQRel, query_json
+from dataclasses import dataclass, field, asdict
 
 
-@attr.s
+@dataclass
 class CoordinateAscentParams:
     """
     This class represents the configuration and parameters available for FastRank's CoordinateAscent Model.
     """
 
-    num_restarts = attr.ib(type=int, default=5)
-    num_max_iterations = attr.ib(type=int, default=25)
-    step_base = attr.ib(type=float, default=0.05)
-    step_scale = attr.ib(type=float, default=2.0)
-    tolerance = attr.ib(type=float, default=0.001)
-    normalize = attr.ib(type=bool, default=True)
-    init_random = attr.ib(type=bool, default=True)
-    output_ensemble = attr.ib(type=bool, default=False)
-    seed = attr.ib(type=int, default=random.randint(0, (1 << 64) - 1))
-    quiet = attr.ib(type=bool, default=False)
+    num_restarts: int = 5
+    num_max_iterations: int = 25
+    step_base: float = 0.05
+    step_scale: float = 2.0
+    tolerance: float = 0.001
+    normalize: bool = True
+    init_random: bool = True
+    output_ensemble: bool = False
+    seed: int = random.randint(0, (1 << 64) - 1)
+    quiet: bool = False
 
     def name(self):
         return "CoordinateAscent"
 
     def to_dict(self):
-        return attr.asdict(self, recurse=True)
+        return asdict(self)
 
     @staticmethod
     def from_dict(params) -> "CoordinateAscentParams":
         return CoordinateAscentParams(**params)
 
 
-@attr.s
+@dataclass
 class RandomForestParams:
     """
     This class represents the configuration and parameters available for FastRank's Random Forest Model.
     """
 
-    num_trees = attr.ib(type=int, default=100)
-    weight_trees = attr.ib(type=bool, default=True)
-    split_method = attr.ib(type=str, default="SquaredError")
-    instance_sampling_rate = attr.ib(type=float, default=0.5)
-    feature_sampling_rate = attr.ib(type=float, default=0.25)
-    min_leaf_support = attr.ib(type=int, default=10)
-    split_candidates = attr.ib(type=int, default=3)
-    max_depth = attr.ib(type=int, default=8)
-    seed = attr.ib(type=int, default=random.randint(0, (1 << 64) - 1))
-    quiet = attr.ib(type=bool, default=False)
+    num_trees: int = 100
+    weight_trees: bool = True
+    split_method: str = "SquaredError"
+    instance_sampling_rate: float = 0.5
+    feature_sampling_rate: float = 0.25
+    min_leaf_support: int = 10
+    split_candidates: int = 3
+    max_depth: int = 8
+    seed: int = random.randint(0, (1 << 64) - 1)
+    quiet: bool = False
 
     def name(self):
         return "RandomForest"
 
     def to_dict(self):
-        return attr.asdict(self, recurse=True)
+        return asdict(self)
 
     @staticmethod
     def from_dict(params) -> "RandomForestParams":
         return RandomForestParams(**params)
 
 
-@attr.s
+@dataclass
 class TrainRequest:
     """
     This class represents the configuration and parameters available to train a model.
@@ -71,12 +71,11 @@ class TrainRequest:
     - `~random_forest`
     """
 
-    measure = attr.ib(type=str, default="ndcg")
-    params = attr.ib(
-        type=Union[CoordinateAscentParams, RandomForestParams],
-        factory=CoordinateAscentParams,
+    measure: str = "ndcg"
+    params: Union[CoordinateAscentParams, RandomForestParams] = field(
+        default_factory=CoordinateAscentParams
     )
-    judgments = attr.ib(type=CQRel, default=None)
+    judgments: Optional[CQRel] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,11 @@
 [project]
 name = "fastrank"
-requires-dist = ["attrs", "cffi", "numpy"]
 classifier = [
-  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["cffi"]
+dependencies = ["cffi", "numpy"]
 
 [build-system]
 requires = ["maturin>=0.14,<0.15", "cffi"]
@@ -14,4 +13,3 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "cffi"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-attrs
 cffi
 numpy
 scikit-learn


### PR DESCRIPTION
Since Github Actions has dropped py3.6, we can now use dataclasses, which were introduced in py3.7.
We can still cut an 0.7 point release from before this PR.
Then we'll release 0.8 with new CI scripts, solving the M1 mac issue.